### PR TITLE
Error message language update

### DIFF
--- a/lib/elixir/lib/kernel.ex
+++ b/lib/elixir/lib/kernel.ex
@@ -1802,7 +1802,7 @@ defmodule Kernel do
   defp invalid_concat_left_argument_error(arg) do
     :erlang.error(
       ArgumentError.exception(
-        "the left argument of <> operator inside a match should be always a literal " <>
+        "the left argument of <> operator inside a match should always be a literal " <>
           "binary as its size can't be verified, got: #{arg}"
       )
     )


### PR DESCRIPTION
"should always be" is preferable in English over "should be always"